### PR TITLE
Add function that clears only the printed lines

### DIFF
--- a/plotext/plot.py
+++ b/plotext/plot.py
@@ -229,8 +229,20 @@ def _filly(fill = None):
 ##############################################
 def clear_terminal():
     _utility.write('\033c')
+    _utility._terminal_printed_lines_cnt = 0
 clear_terminal.__doc__ = _docstrings.clear_terminal_doc
 clt = clear_terminal
+
+def clear_terminal_printed_lines():
+    # clear the lines that plotext had printed
+    # (plus 1 because the last line would not has an \n at the end)
+    n = _utility._terminal_printed_lines_cnt + 1
+    for i in range(n):
+        _utility.write("\033[2K")
+        if i < n - 1:
+            _utility.write("\033[A")
+            _utility.write("\033[2K")
+    _utility._terminal_printed_lines_cnt = 0
 
 def clear_figure():
     _fig.__init__()

--- a/plotext/utility.py
+++ b/plotext/utility.py
@@ -367,8 +367,13 @@ def get_canvas(matrix):
         canvas += '\n'
     return canvas + '\n'
   
+
+_terminal_printed_lines_cnt = 0
+
 def write(string):
+    global _terminal_printed_lines_cnt
     sys.stdout.write(string)
+    _terminal_printed_lines_cnt += string.count('\n')
 
 
 ##############################################


### PR DESCRIPTION
The original `plt.clt()` clears the terminal but destroy all scrollbacks. This PR adds a function that clears only the number of lines that `plotext` had printed.

## Before

```sh
$ python3 -m plotext "import plotext as plt; import numpy as np; l, n = 1000, 2; x = np.arange(0, l); xticks = np.linspace(0, l - 1, 5); xlabels = [str(i) + 'pi' for i in range(5)]; frames = 100; plt.clf(); plt.ylim(-1, 1); plt.xticks(xticks, xlabels); plt.yticks([-1, 0, 1]); plt.plotsize(100, 30); plt.title('Streaming Data'); plt.colorless();  y = lambda i: plt.sin(l, n, 0, phase = 2 * i  / frames); [(plt.cld(), plt.scatter(x, y(i), marker = 'dot'), plt.sleep(0.01), plt.clt(), plt.show()) for i in range(frames)]"

```
![Peek 2021-07-12 14-02](https://user-images.githubusercontent.com/22362177/125229870-fd1b1f00-e31a-11eb-8138-6593011a78fc.gif)

## After

```sh
$ python3 -m plotext "import plotext as plt; import numpy as np; l, n = 1000, 2; x = np.arange(0, l); xticks = np.linspace(0, l - 1, 5); xlabels = [str(i) + 'pi' for i in range(5)]; frames = 100; plt.clf(); plt.ylim(-1, 1); plt.xticks(xticks, xlabels); plt.yticks([-1, 0, 1]); plt.plotsize(100, 30); plt.title('Streaming Data'); plt.colorless();  y = lambda i: plt.sin(l, n, 0, phase = 2 * i  / frames); [(plt.cld(), plt.scatter(x, y(i), marker = 'dot'), plt.sleep(0.01), plt.clear_terminal_printed_lines(), plt.show()) for i in range(frames)]"
```

![Peek 2021-07-12 14-03](https://user-images.githubusercontent.com/22362177/125229887-073d1d80-e31b-11eb-9692-7f3d79dc77e7.gif)


-----------------
P.S. please excuse the jitter in the gif
