### PR TITLE
fix: sys.platform should always use startswith

### DIFF
--- a/plotext/utility.py
+++ b/plotext/utility.py
@@ -380,7 +380,7 @@ def write(string):
 ######    Platform/Shell Functions    ########
 ##############################################
 def platform():
-    if "win" in sys.platform:
+    if sys.platform.startswith("win"):
         return "windows"
     else:
         return "linux"


### PR DESCRIPTION
This fixes #32 by using the correct test for platform - it should always be checked with startswith. In this case, "darwin" (macOS) was matching "win"! Corrected.

In the future, I believe only checking for Windows here is wrong (and it should be overriddable by the user, say by an envvar); the new Windows Terminal is much more like a Unix one, and while that currently requires the Windows store or win-get, that will be the default terminal in Windows 11.

The other suggestions in #32 would be good to implement, and I'll try to help, but for now, this fixes macOS support.
