### PR TITLE
Fix division by zero exception when plotting a dataset with a single bar

### DIFF
--- a/plotext/utility.py
+++ b/plotext/utility.py
@@ -296,7 +296,10 @@ def bar_xdata(x):
 def bars(x, y, width = 4 / 5):
     x, y = x[:], y[:]
     bins = len(x)
-    bin_size_half = (max(x) - min(x)) / (bins - 1) * width / 2
+    bin_size_half = width / 2
+    # adjust the bar width according to the number of bins
+    if bins > 1:
+        bin_size_half *= (max(x) - min(x)) / (bins - 1)
     #bin_size_half = (max(x) - min(x)) / (bins) * width / 2
     #x[0] += bin_size_half
     #x[bins - 1] -= bin_size_half


### PR DESCRIPTION
When a single category is plotted in a bar graph there is a division by zero error. This change handles the single category case.

Here's the code to reproduce the issue:

```python
#!/usr/bin/env python3
import plotext as plt

counts = [1, 2, 3, 4]
categories = ['a', 'b', 'c', 'd']

plt.bar(categories, counts)
plt.plotsize(20, 10)
plt.show()

plt.clear_data()
plt.clear_plot()

counts = [4]
categories = ['d']

plt.bar(categories, counts)
plt.plotsize(20, 10)
plt.show()
```

**Before**
```bash
$ python3 plot.py                                              
   ┌───────────────┐
  4┤           ▐███│
3.3┤       ▗▄▄▄▟███│
2.7┤       ▐███████│
  2┤   ▐███████████│
1.3┤   ▐███████████│
0.7┤███████████████│
  0┤███████████████│
   └─┬───┬───┬───┬─┘
     a   b   c   d  

Traceback (most recent call last):
  File "/host/home/ethan/code/tht/plot.py", line 17, in <module>
    plt.bar(categories, counts)
  File "/usr/local/lib/python3.9/dist-packages/plotext/plot.py", line 934, in bar
    xbar, ybar = _utility.bars(x, y, width)
  File "/usr/local/lib/python3.9/dist-packages/plotext/utility.py", line 299, in bars
    bin_size_half = (max(x) - min(x)) / (bins - 1) * width / 2
ZeroDivisionError: division by zero
```

The problem is that `bins == 1` so `(bins - 1) == 0` in the denominator.

**After**

My proposed change fixes this issue by special casing the `bins == 1` case. (Side note: It also effects the `bins == 0` but that case causes an error elsewhere in the code anyway.)

```bash
$ python3 plot.py
   ┌───────────────┐
  4┤           ▐███│
3.3┤       ▗▄▄▄▟███│
2.7┤       ▐███████│
  2┤   ▐███████████│
1.3┤   ▐███████████│
0.7┤███████████████│
  0┤███████████████│
   └─┬───┬───┬───┬─┘
     a   b   c   d  

   ┌───────────────┐
  4┤███████████████│
3.3┤███████████████│
2.7┤███████████████│
  2┤███████████████│
1.3┤███████████████│
0.7┤███████████████│
  0┤███████████████│
   └───────┬───────┘
           d        
```

![image](https://user-images.githubusercontent.com/1696711/133854480-0a8240b9-232a-4b14-a09b-1d1e11f8498b.png)
