### PR TITLE
Option to show subplots in their set sizes regardless of figure size

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ In order to plot a grid of plots, use the following main functions:
  - `plt.subplots(rows, cols)` creates a matrix of plots with the given number of rows and columns.
  - `plt.subplot(row, col)` access the plot at the given row and column, counting (from 1) from the upper left corner of the matrix of plots, previously set. 
 
+Note that if subplots are manually resized with `plotsize`, they can overflow the figure, in which case they will be cut (and possibly made completely invisible if their size is set to 0). A figure can be automatically resized in the vertical direction to fit all the subplots by passing `allow_scrolling=True` to `show`.
+
 Here is a coded basic example:
 ```
 import plotext as plt
@@ -430,6 +432,7 @@ plt.hist(y, color = "indigo")
 plt.plotsize(100, 27)
 
 plt.show()
+# plt.show(allow_scrolling=True)  # if your terminal is less than 54 px in height
 ```
 ![example](https://raw.githubusercontent.com/piccolomo/plotext/master/images/subplots.png)
 

--- a/plotext/__init__.py
+++ b/plotext/__init__.py
@@ -11,7 +11,7 @@ from test import test
 
 _sys.path.pop(0)
 
-from plotext.plot import *
+from plotext.plot_ import *
 
 __name__ = "plotext"
 __version__ = "3.1.3"

--- a/plotext/plot_.py
+++ b/plotext/plot_.py
@@ -411,7 +411,7 @@ yscale.__doc__ = _docstrings.yscale_doc
 ##############################################
 ###########    Show Functions    #############
 ##############################################
-def show(hide = False):
+def show(hide: bool = False, allow_scrolling: bool = False):
     _figure_size_max()
     _figure_size()
 
@@ -420,14 +420,14 @@ def show(hide = False):
 
     for r in range(_fig.rows):
         for c in range(_fig.cols):
-            
+
             subplot = _fig.subplots[r][c]
 
             _previous_size(subplot)
             
             _sort_data(subplot)
 
-            _height(subplot)
+            _height(subplot, ignore_figure_size=allow_scrolling)
 
             _ylim_data(subplot)
             _ylim_plot(subplot)
@@ -522,13 +522,14 @@ def _sort_data(subplot):
     subplot.data_right = subplot.x_right != [] and subplot.y_right != []
     subplot.data = subplot.data_left or subplot.data_right
     
-def _height(subplot):
+def _height(subplot, ignore_figure_size: bool = False):
     subplot.height_max = _fig.height - _fig.previous_height
     height_none = subplot.height_max // (_fig.rows - subplot.row)
     height = _utility.set_if_none(subplot.height_set, height_none)
     height = abs(int(height))
     
-    height = subplot.height_max if height > subplot.height_max else height
+    if not ignore_figure_size and height > subplot.height_max:
+        height = subplot.height_max
     subplot.height = height
 
     subplot.xaxes[0] = 0 if height < 2 else subplot.xaxes[0]


### PR DESCRIPTION
Linked issue: #45

I have added optional bool flag to show function (turned off by default, preserving backwards compatibility) that disables subplots' height being limited by available terminal height.

Current default behavior doesn't shrink all subplots equally (as one might imagine), but prints them in the specified size until it runs out of terminal height. Then it just cuts the rest (by setting their height to 0) without any notice. After banging my head against the wall for an hour trying to figure out were did my subplots go, I took some time to implement alternative behaviour.