### PR TITLE
Fix the "Issue when formatting tick labels for log scale plots #90"

### DIFF
--- a/plotext/_monitor.py
+++ b/plotext/_monitor.py
@@ -1147,7 +1147,7 @@ side_symbols = {("lower", "left"): 'L', ("lower", "right"): '⅃', ("upper", "le
 
 def get_labels(ticks): # it returns the approximated string version of the data ticks
     d = distinguishing_digit(ticks)
-    labels = [str(ut.round(el, d + 1)) for el in ticks]
+    labels = [f"{ut.round(el, d + 1):f}" for el in ticks]
     labels = [el[: el.index('.') + d + 2] for el in labels]
     labels = [add_extra_zeros(el, d + 1) if len(labels) > 1 else el for el in labels]
     sign = any([el < 0 for el in ticks])


### PR DESCRIPTION
**Implementing the quick fix:**
1)  Replace the line: 

```
    labels = [str(ut.round(el, d + 1)) for el in ticks]
```
2) For this new line:

```
    labels = [f"{ut.round(el, d + 1):f}" for el in ticks]
```

Regards! 🙂