### PR TITLE
Create plotext/__main__.py

### DIFF
--- a/plotext/__main__.py
+++ b/plotext/__main__.py
@@ -1,0 +1,3 @@
+# To be able to run as "python -m plotext"
+from .plotext_cli import main
+main()


### PR DESCRIPTION
This enables the cli to be run as `python -m plotext` without having to configure the `$PATH` for the cli script