### PR TITLE
Fix symbol in legend for braille markers

### DIFF
--- a/plotext/_build.py
+++ b/plotext/_build.py
@@ -254,7 +254,7 @@ class build_class():
         # Add Legend Markers
         take_3 = lambda data: (data[ : 3] * 3)[ : 3]
         marker = [take_3(self.marker[s]) for s in Signals if labelled(s)]
-        replace_hd_marker = lambda marker: '🬗' if marker == 'fhd' else '▞' if marker == 'hd' else marker
+        replace_hd_marker = lambda marker: ut.hd_symbols[marker] if marker in ut.hd_symbols else marker
         marker = [[ut.space] + list(map(replace_hd_marker, el)) for el in marker]
         color =  [[ut.no_color] + take_3(c[s]) for s in Signals if labelled(s)]
         style =  [[ut.no_color] + take_3(st[s]) for s in Signals if labelled(s)]


### PR DESCRIPTION
I noticed that the legend was broken when using braille markers (see screenshot below).  I dived a bit into the code and it seems to be an easy fix:
Instead of explicitly checking marker types, use `ut.hd_symbols` to get the symbol used in the legend ("braille" is already included there).

Before:
![Screenshot_20220929_121126](https://user-images.githubusercontent.com/9333121/193005892-46e2f479-aaa6-4abd-ac06-8a0ed506e3cc.png)

After:
![Screenshot_20220929_121149](https://user-images.githubusercontent.com/9333121/193005914-b6477007-b58e-49aa-9583-aa71a5b25323.png)