### PR TITLE
Fix Compatiblity with Python 3.5

### DIFF
--- a/plotext/_global.py
+++ b/plotext/_global.py
@@ -117,7 +117,7 @@ def _play_video(path, from_youtube = False):
         fr = cap.get(cv2.CAP_PROP_FPS)
     frame_time = 1 / fr 
     #to_list = lambda frame: [[tuple(int(el) for el in tup) for tup in row] for row in frame]
-    pt = lambda time: f'{round(10 ** 3 * time, 1):05.1f}' + '  '
+    pt = lambda time: '{time:05.1f}  '.format(time=round(10 ** 3 * time, 1))
     real_time = video_time = 0
     while True:
         load_time = time()


### PR DESCRIPTION
Commit piccolomo/plotext@63125c9 added an f-string in _global.py which breaks the stated Python3.5 compatibility from setup.py. This change should make it compatible again by using .format() on the string instead of an f-string.