### PR TITLE
Skip the First N Rows in read_data()

### DIFF
--- a/plotext/_core.py
+++ b/plotext/_core.py
@@ -354,8 +354,8 @@ def join_paths(*args):
 def save_text(text, path, log = True):
     return _ut.save_text(text, path, log = log)
 
-def read_data(path, delimiter = None, columns = None):
-    return _ut.read_data(path, delimiter = delimiter, columns = columns)
+def read_data(path, delimiter = None, columns = None, skip_rows = 0):
+    return _ut.read_data(path, delimiter = delimiter, columns = columns, skip_rows = skip_rows)
 
 def write_data(data, path, delimiter = None, columns = None, log = True):
     return _ut.write_data(data, path, delimiter = delimiter, columns = columns, log = log)

--- a/plotext/_utility.py
+++ b/plotext/_utility.py
@@ -220,12 +220,12 @@ def delete_file(path, log = True): # remove the file if it exists
         os.remove(path)
         print(format_strings("file removed:", path, negative_color)) if log else None
 
-def read_data(path, delimiter = None, columns = None, header = None): # it turns a text file into data lists
+def read_data(path, delimiter = None, columns = None, skip_rows=0): # it turns a text file into data lists
     path = correct_path(path)
-    header = True if header is None else header
     file = open(path, "r")
-    begin = int(not header)
-    text = file.readlines()[begin:]
+    for _ in range(skip_rows):
+        next(file)
+    text = file.readlines()
     file.close()
     return read_lines(text, delimiter, columns)
 

--- a/plotext/plotext_cli.py
+++ b/plotext/plotext_cli.py
@@ -37,6 +37,12 @@ def build_parser():
                              metavar = "FILE",
                              help    = "file path of the data table; if not used it will read from stdin. Use 'test' to automatically download, in your user folder, some test data/image/gif or video, depending on the function used; the file will be removed after the plot",
                              ).complete = shtab.FILE
+    path_parser.add_argument("-r", "--skip-rows",
+                             action = "store",
+                             type = int,
+                             default = 0,
+                             metavar = "ROWS",
+                             help = "Skip ROWS rows of the data file.")
 
     common_parser = argparse.ArgumentParser(add_help = False)
 
@@ -237,8 +243,10 @@ def main(argv = None):
     args = parser.parse_args(argv)
 
     type = args.type
+    skip_rows = 0
     if type != "youtube":
         path = args.path
+        skip_rows = args.skip_rows
         clt = True if args.clear_terminal[-1] == 'True' else False
         sleep = args.sleep[0]
 
@@ -303,6 +311,8 @@ def main(argv = None):
                 x, Y = get_xY(data)
                 plot(x, Y)
 
+            for _ in range(skip_rows):
+                sys.stdin.readline()
             text = []
             i = 0
             for line in iter(sys.stdin.readline, ''):
@@ -316,7 +326,7 @@ def main(argv = None):
                 text = []
 
         else:
-            data = plt.read_data(path, delimiter = delimiter)
+            data = plt.read_data(path, delimiter = delimiter, skip_rows = skip_rows)
             data = plt.transpose(data)
             x, Y = get_xY(data)
             chunks = len(x) // lines + (1 if len(x) % lines else 0)


### PR DESCRIPTION
Added command line flag to skip N rows.

This allows you to use a standard CSV file that has one or more header lines as input.