### PR TITLE
Zero Values Erasing the Base of Stacked Bars

### DIFF
--- a/plotext/_monitor.py
+++ b/plotext/_monitor.py
@@ -421,18 +421,20 @@ class monitor_class(build_class):
 
         firstbar = min([b for b in range(len(x)) if ybar[b][1] != 0], default = 0) # finds the position of the first non zero bar
 
+        first_drawn = True
         for b in range(len(x)):
             xb = xbar[b]; yb = ybar[b]
-            plot_label = label if b == firstbar else None
-            plot_color = color if b == 0 else self.color[-1]
             nobar = (yb[1] == 0 and orientation[0] == 'v') or (xb[1] == 0 and orientation[0] == 'h')
-            plot_marker = " " if nobar else marker
-            plot_color = color if b == 0 else self.color[-1][-1]
+            if nobar:
+                continue
+            plot_label = label if b == firstbar else None
+            plot_color = color if first_drawn else self.color[-1][-1]
+            first_drawn = False
             self.draw_rectangle(xb, yb,
-                                xside = xside, 
+                                xside = xside,
                                 yside = yside,
                                 lines = True,
-                                marker = plot_marker,
+                                marker = marker,
                                 color = plot_color,
                                 fill = fill,
                                 label = plot_label)


### PR DESCRIPTION
## Summary

- Zero-value bars in `stacked_bar` drew a space-filled rectangle at the baseline, overwriting bars from other series beneath them
- Changed `draw_bar` to `continue` when `nobar=True` instead of drawing with space markers

Fixes #232

## Test

```python
import plotext as plt
plt.stacked_bar(
    ['d1', 'd2', 'd3', 'd4', 'd5'],
    [[4, 0, 10, 0, 8], [1, 5, 3, 6, 2]],
    labels=['ok', 'fail'],
    color=['green', 'red'],
)
plt.plotsize(60, 20)
plt.show()
```

Before: `d2` and `d4` bars float above the baseline (gap where spaces overwrote the red bar).
After: all bars render correctly from y=0.